### PR TITLE
update dockerfile to include 4.3.0 sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update -qqy && apt-get install -qqy --option Dpkg::Options::="--force-confnew" --no-install-recommends \
     autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev tzdata \
     git libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev \
-    libwebp-dev gettext libmicrohttpd-dev ca-certificates imagemagick curl wget \
+    libwebp-dev gettext gettext-tools libmicrohttpd-dev ca-certificates imagemagick curl wget \
     libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev ffmpeg x264 && \
     apt-get --quiet autoremove --yes && \
     apt-get --quiet --yes clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-url="https://github.com/Motion-Project/motion.git"
 
 #Install base packages
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-    autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev \
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y --option Dpkg::Options::="--force-confnew" --no-install-recommends \
+    install autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev \
     git libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev \
-    libwebp-dev gettext libmicrohttpd-dev ca-certificates imagemagick curl wget tzdata \
+    libwebp-dev gettext libmicrohttpd-dev ca-certificates imagemagick curl wget \
     libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev ffmpeg x264 && \
     apt-get --quiet autoremove --yes && \
     apt-get --quiet --yes clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 LABEL maintainer="TBD"
 
 #Setup parameters

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,18 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/Motion-Project/motion.git"
 
-#Install base packages
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y --option Dpkg::Options::="--force-confnew" --no-install-recommends \
-    install autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev \
+# Setup Timezone packages and avoid all interaction. This will be overwritten by the user when selecting TZ in the run command
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    export DEBCONF_NONINTERACTIVE_SEEN=true; \
+    apt-get update -qqy && apt-get install -qqy --option Dpkg::Options::="--force-confnew" --no-install-recommends \
+    autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev tzdata \
     git libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev \
     libwebp-dev gettext libmicrohttpd-dev ca-certificates imagemagick curl wget \
     libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev ffmpeg x264 && \
     apt-get --quiet autoremove --yes && \
     apt-get --quiet --yes clean && \
     rm -rf /var/lib/apt/lists/*
-    
+
 RUN git clone https://github.com/Motion-Project/motion.git  && \
    cd motion  && \
    autoreconf -fiv && \
@@ -38,7 +40,7 @@ VOLUME /usr/local/etc/motion
 # R/W needed for motion to update Video & images
 VOLUME /var/lib/motion
 
-CMD test -e /usr/local/etc/motion/motion.conf || \    
-    cp /usr/local/etc/motion/motion-dist.conf /usr/local/etc/motion/motion.conf 
+CMD test -e /usr/local/etc/motion/motion.conf || \
+    cp /usr/local/etc/motion/motion-dist.conf /usr/local/etc/motion/motion.conf
 
 CMD [ "motion", "-n" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-url="https://github.com/Motion-Project/motion.git"
 
 #Install base packages
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get install -y --no-install-recommends \
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
     autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev \
     git libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev \
     libwebp-dev gettext libmicrohttpd-dev ca-certificates imagemagick curl wget tzdata \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="TBD"
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.label-schema.build-date=$BUILD_DATE \
-    org.label-schema.docker.dockerfile="extra/Dockerfile" \
+    org.label-schema.docker.dockerfile="Dockerfile" \
     org.label-schema.license="GPLv3" \
     org.label-schema.name="motion" \
     org.label-schema.url="https://motion-project.github.io/" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update -qqy && apt-get install -qqy --option Dpkg::Options::="--force-confnew" --no-install-recommends \
     autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev tzdata \
     git libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev \
-    libwebp-dev gettext gettext-tools libmicrohttpd-dev ca-certificates imagemagick curl wget \
+    libwebp-dev gettext autopoint libmicrohttpd-dev ca-certificates imagemagick curl wget \
     libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev ffmpeg x264 && \
     apt-get --quiet autoremove --yes && \
     apt-get --quiet --yes clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get install -y --no-i
     autoconf automake build-essential pkgconf libtool libzip-dev libjpeg-dev \
     git libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev \
     libwebp-dev gettext libmicrohttpd-dev ca-certificates imagemagick curl wget tzdata \
-    libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev ffmpeg && \
+    libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev ffmpeg x264 && \
     apt-get --quiet autoremove --yes && \
     apt-get --quiet --yes clean && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This container is built automatically whenever code is pushed to master at https
 
 Caveats;
 - If you use /dev/video, locally attached cameras or the database features of Motion, this container won't work for you at this stage.  
-- Bleeding edge code, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases).
+- This is built directly from git master, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases) and install manually.
 
 Run via something like this;
 
@@ -24,9 +24,14 @@ docker run -d --name=motion-project \
     motionproject/motion:latest
 ```
 
-Things to change ;
+Things you will need to change ;
 - name=a label for the container, should be motion or motion-project (but can be anything)
 - ports = each -p line denotes 1 camera and its stream port
 - TZ = the timezone the container will be running
 - volumes = /dockerserver/path/to/config
           = /dockerserver/path/to/storage
+          
+## Release Notes
+- 30/11/18 Cosmetic changes and added x264 package
+- 29/11/18 Initial build of Docker container 
+- 29/10/18 Motion 4.2 released

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker pull motionproject/motion:latest
           = /dockerserver/path/to/storage
           
 ## Release Notes
+- 21/01/19 Triggered new build to capture passthrough fixes from git master
 - 30/11/18 Bumped to Ubuntu 18.04
 - 30/11/18 Cosmetic changes and added x264 package
 - 29/11/18 Initial build of Docker container 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This container is built automatically whenever code is pushed to master at https
 - If you use /dev/video, locally attached cameras or the database features of Motion, this container won't work for you at this stage.  
 - This is built directly from git master, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases) and install manually.
 
-Run via something like this;
+## How to run
+
+something like this;
 
 ```
 docker run -d --name=motion-project \
@@ -23,6 +25,15 @@ docker run -d --name=motion-project \
     --restart=always \
     motionproject/motion:latest
 ```
+## How to Update
+
+```
+docker stop motion-project
+docker rm motion-project
+docker pull motionproject/motion:latest
+rerun above run command
+```
+
 
 ## Things you may need to change
 - name = a label for the container, should be motion or motion-project (but can be anything)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This container is built automatically whenever code is pushed to master at https://github.com/Motion-Project/motion .
 
 Caveats;
-> If you use /dev/video or database features of Motion, this container won't work for you at this stage.  
-> Bleeding edge code, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases).
+- If you use /dev/video or database features of Motion, this container won't work for you at this stage.  
+- Bleeding edge code, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases).
 
 Run via something like this;
 
@@ -23,3 +23,10 @@ docker run -d --name=motion-project \
     --restart=always \
     motionproject/motion:latest
 ```
+
+Things to change ;
+- name=a label for the container, should be motion or motion-project (but can be anything)
+- ports = each -p line denotes 1 camera and its stream port
+- TZ = the timezone the container will be running
+- volumes = /dockerserver/path/to/config
+          = /dockerserver/path/to/storage

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker pull motionproject/motion:latest
           = /dockerserver/path/to/storage
           
 ## Release Notes
+- 29/01/20 Triggered new build to bump to 4.3.0
 - 21/01/19 Triggered new build to capture passthrough fixes from git master
 - 30/11/18 Bumped to Ubuntu 18.04
 - 30/11/18 Cosmetic changes and added x264 package

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This container is built automatically whenever code is pushed to master at https://github.com/Motion-Project/motion .
 
-Caveats;
+## Caveats
 - If you use /dev/video, locally attached cameras or the database features of Motion, this container won't work for you at this stage.  
 - This is built directly from git master, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases) and install manually.
 
@@ -24,14 +24,15 @@ docker run -d --name=motion-project \
     motionproject/motion:latest
 ```
 
-Things you will need to change ;
-- name=a label for the container, should be motion or motion-project (but can be anything)
+## Things you may need to change
+- name = a label for the container, should be motion or motion-project (but can be anything)
 - ports = each -p line denotes 1 camera and its stream port
 - TZ = the timezone the container will be running
 - volumes = /dockerserver/path/to/config
           = /dockerserver/path/to/storage
           
 ## Release Notes
+- 30/11/18 Bumped to Ubuntu 18.04
 - 30/11/18 Cosmetic changes and added x264 package
 - 29/11/18 Initial build of Docker container 
 - 29/10/18 Motion 4.2 released

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ docker run -d --name=motion \
 ## How to Update
 
 ```
-docker stop motion-project
-docker rm motion-project
+docker stop motion
+docker rm motion
 docker pull motionproject/motion:latest
-rerun above run command
+- rerun above run command
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This container is built automatically whenever code is pushed to master at https
 something like this;
 
 ```
-docker run -d --name=motion-project \
+docker run -d --name=motion \
     -p 7999:7999 \
     -p 8081:8081 \
     -p 8082:8082 \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This container is built automatically whenever code is pushed to master at https://github.com/Motion-Project/motion .
 
 Caveats;
-- If you use /dev/video or database features of Motion, this container won't work for you at this stage.  
+- If you use /dev/video, locally attached cameras or the database features of Motion, this container won't work for you at this stage.  
 - Bleeding edge code, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases).
 
 Run via something like this;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # motion-docker
 
-If you use /dev/video or database features of Motion, this container won't work for you at this stage.
+This container is built automatically whenever code is pushed to master at https://github.com/Motion-Project/motion .
+
+Caveats;
+> If you use /dev/video or database features of Motion, this container won't work for you at this stage.  
+> Bleeding edge code, if you want something more stable grab a prebuilt release from [here](https://github.com/Motion-Project/motion/releases).
 
 Run via something like this;
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # motion-docker
 
-This container is built automatically whenever code is pushed to master at https://github.com/Motion-Project/motion .
+This container is built automatically whenever code is pushed to master at https://github.com/Motion-Project/motion-docker.
 
 ## Caveats
 - If you use /dev/video, locally attached cameras or the database features of Motion, this container won't work for you at this stage.  
@@ -31,7 +31,7 @@ docker run -d --name=motion \
 docker stop motion
 docker rm motion
 docker pull motionproject/motion:latest
-- rerun above run command
+- rerun above 'run' command
 ```
 
 


### PR DESCRIPTION
i've been running this docker container for a few days and it's been reliable.

autopoint is added as a package, as this appears required under latest git source
timezone selection works well, with location set as a docker ENV variable (as per readme)

Been a while since we changed this though